### PR TITLE
Update Profile.php

### DIFF
--- a/core/modules/Profile/Profile.php
+++ b/core/modules/Profile/Profile.php
@@ -197,6 +197,7 @@ class Profile extends CodonModule
 		
 		$fields = RegistrationData::getCustomFields();
 		
+		if(is_array($fields) || $fields instanceof Countable)
 		if(count($fields) > 0) {
             		foreach ($fields as $field) {
 				$value = Vars::POST($field->fieldname);


### PR DESCRIPTION
When saving changes in edit profile, a warning comes up.

 Warning: count(): Parameter must be an array or an object that implements Countable in C:\wamp64\www\phpvms_5.5.x-master\core\modules\Profile\Profile.php on line 200

Added
if(is_array ($fields) || $fields instanceof Countable)
before ln200