### PR TITLE
Update SchedulesData.class.php

### DIFF
--- a/core/common/SchedulesData.class.php
+++ b/core/common/SchedulesData.class.php
@@ -801,7 +801,8 @@ class SchedulesData extends CodonData {
 				WHERE `dateadded` + INTERVAL {$cache_time} HOUR < NOW()";
 
         $results = DB::get_results($sql);
-        if (count($results) > 0) {
+        if(is_array($results) || $results intanceof Countable)
+	if (count($results) > 0) {
             foreach ($results as $row) {
                 $sql = 'UPDATE ' . TABLE_PREFIX . "schedules
 						SET `bidid`=0 WHERE `id`={$row->routeid}";


### PR DESCRIPTION
Warning: count(): Parameter must be an array or an object that implements Countable in C:\wamp64\www\phpvms_5.5.x-master\core\common\SchedulesData.class.php on line 804

This seems to only appear on initial start of Wamp and phpVMS from a fresh boot of computer. Will attempt fix with: if(is_array ($foo) || $foo instanceof Countable) -- placed before line 804

Added
if(is_array($results) || $results intanceof Countable)
before ln804