### PR TITLE
New Pilot Registration

### DIFF
--- a/core/common/RSSFeed.class.php
+++ b/core/common/RSSFeed.class.php
@@ -20,7 +20,7 @@
 class RSSFeed {
     var $feed_contents;
 
-    public function RSSFeed($title = '', $url = '', $description = '') {
+    public function __construct($title = '', $url = '', $description = '') {
 
         $last_build_date = $this->LastBuildDate();
 


### PR DESCRIPTION
Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; RSSFeed has a deprecated constructor in C:\wamp64\www\phpvms_5.5.x.72\core\common\RSSFeed.class.php on line 20

Even though the error shows line 20, you don't want to change the class - so you change the public function instead.

Changed line 23 from
public function RSSFeed
to
public function __construct