### PR TITLE
Update Import.php

### DIFF
--- a/admin/modules/Import/Import.php
+++ b/admin/modules/Import/Import.php
@@ -479,7 +479,8 @@ class Import extends CodonModule {
 
         echo '</div>';
 
-        unlink($new_name);
+        fclose($fp);
+	unlink($new_name);
     }
 
     protected function get_airport_info($icao) {


### PR DESCRIPTION
Warning: unlink(C:\wamp64\www\phpvms_5.5.x-master\core\cacheschedules.csv): Resource temporarily unavailable in C:\wamp64\www\phpvms_5.5.x-master\admin\modules\Import\Import.php on line 482

Added
fclose($fp);
before line 482

This make the Warning go away. The 'fclose' is needed because the file was still open and couldn't be removed.

There were some issues with the schedules table that will be addressed separately.