### PR TITLE
New Pilot Registration

### DIFF
--- a/core/lib/phpmailer/PHPMailerAutoload.php
+++ b/core/lib/phpmailer/PHPMailerAutoload.php
@@ -37,13 +37,14 @@ if (version_compare(PHP_VERSION, '5.1.2', '>=')) {
     } else {
         spl_autoload_register('PHPMailerAutoload');
     }
-} else {
+# Deprecated __autoload() is deprecated, use spl_autoload_register() instead - no fallback
+#} else {
     /**
      * Fall back to traditional autoload for old PHP versions
      * @param string $classname The name of the class to load
      */
-    function __autoload($classname)
-    {
-        PHPMailerAutoload($classname);
-    }
+#    function __autoload($classname)
+#    {
+#        PHPMailerAutoload($classname);
+#    }
 }


### PR DESCRIPTION
Deprecated:  __autoload() is deprecated, use spl_autoload_register() instead in C:\wamp64\www\phpvms_5.5.x.72\core\lib\phpmailer\PHPMailerAutoload.php on line 45

Commented out offending lines and added note as to why.