### PR TITLE
Update Import.php

### DIFF
--- a/admin/modules/Import/Import.php
+++ b/admin/modules/Import/Import.php
@@ -279,7 +279,8 @@ class Import extends CodonModule {
             $total++;
         }
 
-        unlink($new_name);
+        fclose($fp);
+	unlink($new_name);
 
         echo "The import process is complete, added {$added} aircraft, updated {$updated}, for a total of {$total}<br />";
     }


### PR DESCRIPTION
 Warning: unlink(C:\wamp64\www\phpvms_5.5.x.72\core\cacheaircraft.csv): Resource temporarily unavailable in C:\wamp64\www\phpvms_5.5.x.72\admin\modules\Import\Import.php on line 283

Adding 'fclose($fp);' fixes issue. This was the same in import schedules.